### PR TITLE
scripts/build.js was still for old steal

### DIFF
--- a/srchr/scripts/build.js
+++ b/srchr/scripts/build.js
@@ -1,6 +1,6 @@
 //steal/js srchr/scripts/compress.js
-load("steal/rhino/steal.js");
-steal.plugins('steal/build', 'steal/build/scripts', 'steal/build/styles', function() {
+load("steal/rhino/rhino.js");
+steal('steal/build', 'steal/build/scripts', 'steal/build/styles', function() {
 	steal.build('srchr/srchr.html', {
 		to: 'srchr'
 	});


### PR DESCRIPTION
scripts/build.js was still for old steal.

I changed it so it that the build script works.
